### PR TITLE
Add channel-slug to Page type

### DIFF
--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -1,9 +1,9 @@
 import datetime
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Model, QuerySet
 from django.http import HttpRequest
 from django.utils.functional import empty
 
@@ -89,7 +89,10 @@ class ChannelContext(BaseContext[N]):
     channel_slug: str | None
 
 
+M = TypeVar("M", bound=Model)
+
+
 @dataclass
-class ChannelQsContext:
-    qs: QuerySet
+class ChannelQsContext(Generic[M]):
+    qs: QuerySet[M]
     channel_slug: str | None

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -7,6 +7,7 @@ from graphql import GraphQLError
 from ...attribute import AttributeInputType
 from ...attribute.models import AssignedPageAttributeValue, Attribute, AttributeValue
 from ...page import models
+from ..core.context import ChannelQsContext
 from ..core.doc_category import DOC_CATEGORY_PAGES
 from ..core.filters import (
     FilterInputObjectType,
@@ -41,14 +42,15 @@ from ..utils.filters import (
 from .types import Page, PageType
 
 
-def search_pages(qs, value):
+def search_pages(channel_qs: ChannelQsContext, value):
     if not value:
-        return qs
-    return qs.filter(
+        return channel_qs
+    channel_qs.qs = channel_qs.qs.filter(
         Q(title__trigram_similar=value)
         | Q(slug__trigram_similar=value)
         | Q(content__icontains=value)
     )
+    return channel_qs
 
 
 def filter_page_page_types(qs, _, value):

--- a/saleor/graphql/page/tests/queries/test_page.py
+++ b/saleor/graphql/page/tests/queries/test_page.py
@@ -18,6 +18,7 @@ PAGE_QUERY = """
             id
             title
             slug
+            created
             pageType {
                 id
             }
@@ -787,3 +788,232 @@ def test_page_attribute_with_referenced_product_object(
     assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
         "Product", product.id
     )
+
+
+QUERY_PAGE_WITH_ATTRIBUTE_AND_CHANNEL = """
+query Page($id: ID!, $channel: String) {
+  page(id: $id, channel: $channel) {
+    attributes {
+      attribute {
+        id
+        slug
+      }
+      values {
+        reference
+        referencedObject {
+          __typename
+          ... on Page {
+            id
+          }
+          ... on ProductVariant {
+            id
+            pricing {
+              onSale
+            }
+          }
+          ... on Product {
+            id
+            created
+            pricing {
+              onSale
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_page_attribute_with_referenced_page_object_and_channel_slug(
+    staff_api_client,
+    page_type_page_reference_attribute,
+    permission_manage_pages,
+    page,
+    channel_USD,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    # Create a second page to reference
+    referenced_page = Page.objects.create(
+        title="Referenced Page",
+        slug="referenced-page",
+        page_type=page.page_type,
+        is_published=True,
+    )
+
+    page_type = page.page_type
+    page_type.page_attributes.all().delete()
+    page_type.page_attributes.add(page_type_page_reference_attribute)
+
+    attribute_value = AttributeValue.objects.create(
+        attribute=page_type_page_reference_attribute,
+        name=f"Page {referenced_page.pk}",
+        slug=f"page-{referenced_page.pk}",
+        reference_page=referenced_page,
+    )
+
+    associate_attribute_values_to_instance(
+        page, {page_type_page_reference_attribute.pk: [attribute_value]}
+    )
+
+    query = QUERY_PAGE_WITH_ATTRIBUTE_AND_CHANNEL
+
+    # when
+    variables = {
+        "id": graphene.Node.to_global_id("Page", page.pk),
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    page_data = content["data"]["page"]
+    page_attributes = page_data["attributes"]
+    assert len(page_attributes) == 1
+
+    attribute_with_reference = page_attributes[0]
+    assert attribute_with_reference["attribute"]["slug"] == "page-reference"
+
+    assert len(attribute_with_reference["values"]) == 1
+    value = attribute_with_reference["values"][0]
+    assert value["reference"] == graphene.Node.to_global_id("Page", referenced_page.id)
+    assert value["referencedObject"]["__typename"] == "Page"
+    assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
+        "Page", referenced_page.id
+    )
+
+
+def test_page_attribute_with_referenced_product_variant_object_and_channel_slug(
+    staff_api_client,
+    page_type_variant_reference_attribute,
+    permission_manage_pages,
+    page,
+    product,
+    channel_USD,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    product_variant = product.variants.first()
+    page_type = page.page_type
+    page_type.page_attributes.all().delete()
+    page_type.page_attributes.add(page_type_variant_reference_attribute)
+
+    attribute_value = AttributeValue.objects.create(
+        attribute=page_type_variant_reference_attribute,
+        name=f"Variant {product_variant.pk}",
+        slug=f"variant-{product_variant.pk}",
+        reference_variant=product_variant,
+    )
+
+    associate_attribute_values_to_instance(
+        page,
+        {page_type_variant_reference_attribute.pk: [attribute_value]},
+    )
+
+    query = QUERY_PAGE_WITH_ATTRIBUTE_AND_CHANNEL
+
+    # when
+    variables = {
+        "id": graphene.Node.to_global_id("Page", page.pk),
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    page_data = content["data"]["page"]
+    page_attributes = page_data["attributes"]
+    assert len(page_attributes) == 1
+
+    attribute_with_reference = page_attributes[0]
+    assert attribute_with_reference["attribute"]["slug"] == "variant-reference"
+
+    assert len(attribute_with_reference["values"]) == 1
+    value = attribute_with_reference["values"][0]
+    assert value["reference"] == graphene.Node.to_global_id(
+        "ProductVariant", product_variant.id
+    )
+    assert value["referencedObject"]["__typename"] == "ProductVariant"
+    # having pricing object means that we passed channel_slug to the variant
+    assert value["referencedObject"]["pricing"]
+
+
+def test_page_attribute_with_referenced_product_object_and_channel_slug(
+    staff_api_client,
+    page_type_product_reference_attribute,
+    permission_manage_pages,
+    page,
+    product,
+    channel_USD,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    page_type = page.page_type
+    page_type.page_attributes.all().delete()
+    page_type.page_attributes.add(page_type_product_reference_attribute)
+
+    attribute_value = AttributeValue.objects.create(
+        attribute=page_type_product_reference_attribute,
+        name=f"Product {product.pk}",
+        slug=f"product-{product.pk}",
+        reference_product=product,
+    )
+
+    associate_attribute_values_to_instance(
+        page,
+        {page_type_product_reference_attribute.pk: [attribute_value]},
+    )
+
+    query = QUERY_PAGE_WITH_ATTRIBUTE_AND_CHANNEL
+
+    # when
+    variables = {
+        "id": graphene.Node.to_global_id("Page", page.pk),
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    page_data = content["data"]["page"]
+    page_attributes = page_data["attributes"]
+    assert len(page_attributes) == 1
+
+    attribute_with_reference = page_attributes[0]
+    assert attribute_with_reference["attribute"]["slug"] == "product-reference"
+
+    assert len(attribute_with_reference["values"]) == 1
+    value = attribute_with_reference["values"][0]
+    assert value["reference"] == graphene.Node.to_global_id("Product", product.id)
+    assert value["referencedObject"]["__typename"] == "Product"
+    # having pricing object means that we passed channel_slug to the product
+    assert value["referencedObject"]["pricing"]
+
+
+def test_page_channel_not_found(staff_api_client, page, permission_manage_pages):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_pages)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Page", page.pk),
+        "channel": "not-existing-channel",
+    }
+    query = """
+    query Page($id: ID!, $channel: String) {
+        page(id: $id, channel: $channel) {
+            id
+        }
+    }
+    """
+
+    # when
+    response = staff_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["page"] is None

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -46,10 +46,16 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                     ... on ProductVariant {
                         id
                         created
+                        pricing {
+                            onSale
+                        }
                     }
                     ... on Product {
                         id
                         created
+                        pricing {
+                            onSale
+                        }
                     }
                 }
               }
@@ -72,10 +78,16 @@ QUERY_PRODUCT_AND_VARIANTS_ATTRIBUTES = """
                     ... on ProductVariant {
                         id
                         created
+                        pricing {
+                            onSale
+                        }
                     }
                     ... on Product {
                         id
                         created
+                        pricing {
+                            onSale
+                        }
                     }
                   }
                 }
@@ -1904,6 +1916,8 @@ def test_product_attribute_with_referenced_product_variant_object(
     assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
         "ProductVariant", product_variant.id
     )
+    # having pricing object means that we passed channel_slug to the variant
+    assert value["referencedObject"]["pricing"]
 
 
 def test_product_attribute_with_referenced_product_object(
@@ -1954,6 +1968,8 @@ def test_product_attribute_with_referenced_product_object(
     assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
         "Product", product.id
     )
+    # having pricing object means that we passed channel_slug to the product
+    assert value["referencedObject"]["pricing"]
 
 
 def test_product_variant_attribute_with_referenced_page_object(
@@ -2061,6 +2077,8 @@ def test_product_variant_attribute_with_referenced_product_variant_object(
     assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
         "ProductVariant", product_variant.id
     )
+    # having pricing object means that we passed channel_slug to the variant
+    assert value["referencedObject"]["pricing"]
 
 
 def test_product_variant_attribute_with_referenced_product_object(
@@ -2113,3 +2131,5 @@ def test_product_variant_attribute_with_referenced_product_object(
     assert value["referencedObject"]["id"] == graphene.Node.to_global_id(
         "Product", product.id
     )
+    # having pricing object means that we passed channel_slug to the product
+    assert value["referencedObject"]["pricing"]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -684,6 +684,13 @@ type Query {
     Added in Saleor 3.21.
     """
     slugLanguageCode: LanguageCodeEnum
+
+    """
+    Slug of a channel for which the data should be returned.
+    
+    Added in Saleor 3.22.
+    """
+    channel: String
   ): Page @doc(category: "Pages")
 
   """List of the shop's pages."""
@@ -707,6 +714,13 @@ type Query {
     Added in Saleor 3.22.
     """
     where: PageWhereInput
+
+    """
+    Slug of a channel for which the data should be returned.
+    
+    Added in Saleor 3.22.
+    """
+    channel: String
 
     """Return the elements in the list that come before the specified cursor."""
     before: String

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -120,7 +120,7 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.CATEGORY:
             qs = resolve_categories(info)
         elif kind == TranslatableKinds.PAGE:
-            qs = resolve_pages(info)
+            qs = resolve_pages(info).qs
         elif kind == TranslatableKinds.SHIPPING_METHOD:
             qs = resolve_shipping_methods(info)
         elif kind == TranslatableKinds.VOUCHER:


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17927

I want to merge this change because it allows you to use to get `AttributeValue.referncedObject` fulfilled with channel-related details.
So query like this:
```grapqhl
query Page($id: ID!, $channel: String) {
  page(id: $id, channel: $channel) {
    attributes {
      values {
        referencedObject {
          __typename
          ... on ProductVariant {
            id
            pricing {
              onSale
            }
          }
        }
      }
    }
  }
}
```
w...